### PR TITLE
Fail fast if docker pull fails

### DIFF
--- a/ras-compose.sh
+++ b/ras-compose.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # stop all running containers
 down() {


### PR DESCRIPTION
Make it known when the docker pull fails if iac cannot be pulled if
the user is not logged in. They will see this error
ERROR: pull access denied for sdcplatform/iacsvc, repository does
not exist or may require 'docker login'