### PR TITLE
Add cfdatabasetool to docker compose

### DIFF
--- a/docker-compose-dev_env.yml
+++ b/docker-compose-dev_env.yml
@@ -26,3 +26,10 @@ services:
     ports:
         - "${EX_SFTP_PORT}:22"
     command: centos:JLibV2&XD,:1001
+ cfdatabasetool:
+  container_name: cfdatabasetool
+  image: sdcplatform/cfdatabasetool
+  environment:
+   - spring.datasource.url=jdbc:postgresql://postgres:5432/postgres
+  ports:
+   - "9000:9000"


### PR DESCRIPTION
The tests use cfdatabasetool to execute sql for setting up data.
Including in the dev compose setup file should enable integration tests
to be ran locally out of the box.